### PR TITLE
Change timestep in time-averaging-interval test to flag rounding errors

### DIFF
--- a/test/test_netcdf_output_writer.jl
+++ b/test/test_netcdf_output_writer.jl
@@ -606,7 +606,7 @@ function test_netcdf_spatial_average(arch)
                                 closure = nothing)
     set!(model, c=1)
 
-    Δt = 1/64 # Nice floating-point number
+    Δt = 0.01 # Floating point number chosen conservatively to flag rounding errors
     simulation = Simulation(model, Δt=Δt, stop_iteration=10)
 
     ∫c_dx = Field(Average(model.tracers.c, dims=(1)))


### PR DESCRIPTION
@liuchihl found that this test was erroneously passing because the timestep that was chosen just happened to not be very prone to the rounding errors that cause this bug: https://github.com/CliMA/Oceananigans.jl/issues/3670

I have changed the timestep to the nearby value of 0.01, which should be more useful in testing against bugs related floating point rounding errors in the future!

